### PR TITLE
Auto populate topic

### DIFF
--- a/app/questions/routes.py
+++ b/app/questions/routes.py
@@ -4,7 +4,7 @@ from app.questions.forms import QuestionForm
 from app.answers.forms import QAForm
 from app.models import Question, Topic, User
 
-from flask import render_template, flash, redirect, url_for, jsonify
+from flask import render_template, flash, redirect, url_for, jsonify, request
 from flask_login import current_user, login_user, logout_user, login_required
 
 
@@ -31,7 +31,12 @@ def create():
 @bp.route('/new', methods=['GET'])
 def new():
   form = QuestionForm()
-  form.topic_id.choices = [(t.id, t.name) for t in Topic.query.order_by('name')]
+  topic = request.args.get('topic') # argument passed in url by New Question button on Topic Detail page
+  if topic: # if topic argument is present, populate new question's topic dropdown with this topic
+    t = Topic.query.filter_by(id=topic).first()
+    form.topic_id.choices = [(t.id, t.name)]
+  else: # if topic argument is not present, populate new question's topic dropdown wtith all topic ids
+    form.topic_id.choices = [(t.id, t.name) for t in Topic.query.order_by('name')]
   backroute = '/questions/create'
   verb = 'POST'
   return render_template('question_form.html', title='Ask Question', form=form, backroute=backroute, verb=verb)
@@ -57,7 +62,10 @@ def update(id):
 def edit(id):
   question = Question.query.filter_by(id=id).first()
   form = QuestionForm(obj=question) # pre-populate the form with the representation of the current record in the DB
+  #form.topic_id.choices = [(question.topic.id, question.topic.name)]
+  #form.topic_id.choices = [(t.id, t.name) for t in Topic.query.order_by('name')]
   form.topic_id.choices = [(t.id, t.name) for t in Topic.query.order_by('name')]
+  form.topic_id.default = [(question.topic.id, question.topic.name)]
   backroute = '/questions/' + id
   verb = 'POST'
   return render_template('question_form.html', title='Edit Question', form=form, backroute=backroute, verb=verb)

--- a/app/questions/routes.py
+++ b/app/questions/routes.py
@@ -62,10 +62,8 @@ def update(id):
 def edit(id):
   question = Question.query.filter_by(id=id).first()
   form = QuestionForm(obj=question) # pre-populate the form with the representation of the current record in the DB
-  #form.topic_id.choices = [(question.topic.id, question.topic.name)]
-  #form.topic_id.choices = [(t.id, t.name) for t in Topic.query.order_by('name')]
   form.topic_id.choices = [(t.id, t.name) for t in Topic.query.order_by('name')]
-  form.topic_id.default = [(question.topic.id, question.topic.name)]
+  form.topic_id.default = [(question.topic.id, question.topic.name)] # set the default value of the topic dropdown to the question's current topic
   backroute = '/questions/' + id
   verb = 'POST'
   return render_template('question_form.html', title='Edit Question', form=form, backroute=backroute, verb=verb)

--- a/app/topics/templates/topic_detail.html
+++ b/app/topics/templates/topic_detail.html
@@ -20,7 +20,7 @@
       <h5 class="mb-3">{{ topic.questions | list | count }} {% if topic.questions | list | count ==1 %} Question {% else %} Questions {% endif %}</h5>
     </div>
     <div class="col">
-      <a class=" btn btn-primary btn-sm float-right" href="{{ url_for('questions.new') }}" style="font-size: .75em;">Ask Question</a>
+      <a class=" btn btn-primary btn-sm float-right" href="{{ url_for('questions.new', topic=topic.id) }}" style="font-size: .75em;">Ask Question</a>
     </div>
   </div>
 


### PR DESCRIPTION
When creating a new question from a Topic Detail page, this auto-populates the Topic dropdown on the New Question form with the name of the topic the user originated from.

- a url argument (topic) is passed containing a topic id
- if the argument is present, the dropdown is populated with the name of the topic containing that id
- if the argument is not present, the dropdown is populated with all arguments

When editing a question, the Topic Dropdown is populated with all possible topics; however, the current topic for that question is the default value displayed in the dropdown.