### PR TITLE
Increase Question Preview Length

### DIFF
--- a/app/topics/templates/topic_detail.html
+++ b/app/topics/templates/topic_detail.html
@@ -42,7 +42,7 @@
           <h5 class="card-title">
             <a href="{{ url_for('questions.show', id=q.id) }}">{{ q.text }}</a>
           </h5>
-          <p class="text-muted">{{ q.description|truncate(100) }}</p>
+          <p class="text-muted">{{ q.description|truncate(300) }}</p>
         </div>
       </div>  
     </div>


### PR DESCRIPTION
increase question preview length to 300 characters on the Topic Detail view.